### PR TITLE
Add Mantra – session time-machine for AI coding tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 | **[webdevtodayjason/sub-agents](https://github.com/webdevtodayjason/sub-agents)** | CLI Manager | NPM installable, context-forge integration, bulk management |
 | **[baryhuang/claude-code-by-agents](https://github.com/baryhuang/claude-code-by-agents)** | Desktop app | Multi-agent workspace, @agent mentions, local+remote agents |
 | **[Dicklesworthstone/claude_code_agent_farm](https://github.com/Dicklesworthstone/claude_code_agent_farm)** | Orchestration | Multiple Claude sessions in parallel, systematic codebase improvement |
+| **[Mantra](https://github.com/mantra-hq/mantra-releases)** | Session time-machine | Local-first session snapshots for Claude Code, Cursor, Windsurf, Augment Code; browse/restore any previous conversation state |
 
 ### **Individual Contributor Collections**
 


### PR DESCRIPTION
## Summary

- Adds [Mantra](https://github.com/mantra-hq/mantra-releases) to the **Specialized Frameworks & Tools** table
- Mantra is a local-first session time-machine for AI coding tools (Claude Code, Cursor, Gemini CLI, Codex, Augment Code (Windsurf: In Development)) that automatically snapshots sessions and lets you browse/restore any previous conversation state
- Install: `curl -fsSL https://mantra.gonewx.com/install.sh | bash`

## Links

- Website: https://mantra.gonewx.com
- GitHub: https://github.com/mantra-hq/mantra-releases

## Checklist

- [x] Added to the appropriate section (Specialized Frameworks & Tools)
- [x] Follows existing table format (Repository | Purpose | Key Features)