### PR TITLE
Add claude-skills to Production-Ready Agent Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 | **[vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents)** | 26 | Jul 2025 | AI development team with Tech Lead, Analyst, and specialized domain experts |
 | **[davepoon/claude-code-subagents-collection](https://github.com/davepoon/claude-code-subagents-collection)** | 36 | Jul 2025 | Comprehensive collection with auto-delegation and best practices guide |
 | **[charles-adedotun/claude-code-sub-agents](https://github.com/charles-adedotun/claude-code-sub-agents)** | Full ecosystem | Jul 2025 | Workflow-stage based system mapping entire dev lifecycle |
+| **[alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills)** | 177 skills, 16 agents | Mar 2026 | Skill packages with Python tools across engineering, marketing, product, compliance. 17 slash commands. Supports 11 AI coding tools. |
 
 ### **Specialized Frameworks & Tools**
 


### PR DESCRIPTION
Adds [claude-skills](https://github.com/alirezarezvani/claude-skills) to the Production-Ready Agent Collections table.

- 177 skill packages across engineering, marketing, product, compliance, and C-level advisory
- 16 agents and 17 slash commands
- Each skill includes structured instructions (SKILL.md), many with Python automation tools and reference documents
- Supports Claude Code and 10 other AI coding tools via a conversion script
- 4,400+ stars, 490+ forks