### PR TITLE
Add Hindsight - AI agent memory by Vectorize

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 | **[webdevtodayjason/sub-agents](https://github.com/webdevtodayjason/sub-agents)** | CLI Manager | NPM installable, context-forge integration, bulk management |
 | **[baryhuang/claude-code-by-agents](https://github.com/baryhuang/claude-code-by-agents)** | Desktop app | Multi-agent workspace, @agent mentions, local+remote agents |
 | **[Dicklesworthstone/claude_code_agent_farm](https://github.com/Dicklesworthstone/claude_code_agent_farm)** | Orchestration | Multiple Claude sessions in parallel, systematic codebase improvement |
-| **[Hindsight by Vectorize](https://hindsight.vectorize.io)** | Long-term Memory | State-of-the-art AI agent memory, open source, [Claude Code integration](https://hindsight.vectorize.io/integrations) |
+| **[vectorize-io/hindsight](https://github.com/vectorize-io/hindsight)** | Long-term Memory | AI agent memory, open source, [Claude Code integration](https://hindsight.vectorize.io/integrations) |
 
 ### **Individual Contributor Collections**
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 | **[webdevtodayjason/sub-agents](https://github.com/webdevtodayjason/sub-agents)** | CLI Manager | NPM installable, context-forge integration, bulk management |
 | **[baryhuang/claude-code-by-agents](https://github.com/baryhuang/claude-code-by-agents)** | Desktop app | Multi-agent workspace, @agent mentions, local+remote agents |
 | **[Dicklesworthstone/claude_code_agent_farm](https://github.com/Dicklesworthstone/claude_code_agent_farm)** | Orchestration | Multiple Claude sessions in parallel, systematic codebase improvement |
+| **[Hindsight by Vectorize](https://hindsight.vectorize.io)** | Long-term Memory | State-of-the-art AI agent memory, open source, [Claude Code integration](https://hindsight.vectorize.io/integrations) |
 
 ### **Individual Contributor Collections**
 


### PR DESCRIPTION
## Summary
- Adds [Hindsight](https://hindsight.vectorize.io) to the Specialized Frameworks & Tools section
- Hindsight is a state-of-the-art, MIT-licensed open-source long-term memory system for AI agents by Vectorize, with a dedicated [Claude Code integration](https://hindsight.vectorize.io/integrations)
- GitHub: https://github.com/vectorize-io/hindsight