### PR TITLE
Add zetetic-team-subagents to Production-Ready Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 | **[vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents)** | 26 | Jul 2025 | AI development team with Tech Lead, Analyst, and specialized domain experts |
 | **[davepoon/claude-code-subagents-collection](https://github.com/davepoon/claude-code-subagents-collection)** | 36 | Jul 2025 | Comprehensive collection with auto-delegation and best practices guide |
 | **[charles-adedotun/claude-code-sub-agents](https://github.com/charles-adedotun/claude-code-sub-agents)** | Full ecosystem | Jul 2025 | Workflow-stage based system mapping entire dev lifecycle |
+| **[cdeust/zetetic-team-subagents](https://github.com/cdeust/zetetic-team-subagents)** | 115 (97 genius + 18 team) | Apr 2026 | 97 reasoning patterns from history's greatest thinkers, zetetic epistemic standard, shape-based routing, 63 skills, 14 hooks, per-agent model overrides, pairs with [Cortex](https://github.com/cdeust/Cortex) for persistent memory |
 
 ### **Specialized Frameworks & Tools**
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 | **[vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents)** | 26 | Jul 2025 | AI development team with Tech Lead, Analyst, and specialized domain experts |
 | **[davepoon/claude-code-subagents-collection](https://github.com/davepoon/claude-code-subagents-collection)** | 36 | Jul 2025 | Comprehensive collection with auto-delegation and best practices guide |
 | **[charles-adedotun/claude-code-sub-agents](https://github.com/charles-adedotun/claude-code-sub-agents)** | Full ecosystem | Jul 2025 | Workflow-stage based system mapping entire dev lifecycle |
-| **[cdeust/zetetic-team-subagents](https://github.com/cdeust/zetetic-team-subagents)** | 115 (97 genius + 18 team) | Apr 2026 | 97 reasoning patterns from history's greatest thinkers, zetetic epistemic standard, shape-based routing, 63 skills, 14 hooks, per-agent model overrides, pairs with [Cortex](https://github.com/cdeust/Cortex) for persistent memory |
+| **[cdeust/zetetic-team-subagents](https://github.com/cdeust/zetetic-team-subagents)** | 115 | Apr 2026 | 97 reasoning patterns, zetetic standard, shape-based routing, and [Cortex](https://github.com/cdeust/Cortex) integration |
 
 ### **Specialized Frameworks & Tools**
 


### PR DESCRIPTION
## Summary

Adds [zetetic-team-subagents](https://github.com/cdeust/zetetic-team-subagents) to **Production-Ready Agent Collections**. 115 agents (97 genius + 18 team), zetetic epistemic standard, shape-based routing, 63 skills, 14 hooks, per-agent model overrides. Pairs with [Cortex](https://github.com/cdeust/Cortex).

## Checklist
- [x] Entry follows table format
- [x] Repository link valid, v2.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)