### PR TITLE
Add Helium MCP to specialized frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 | **[webdevtodayjason/sub-agents](https://github.com/webdevtodayjason/sub-agents)** | CLI Manager | NPM installable, context-forge integration, bulk management |
 | **[baryhuang/claude-code-by-agents](https://github.com/baryhuang/claude-code-by-agents)** | Desktop app | Multi-agent workspace, @agent mentions, local+remote agents |
 | **[Dicklesworthstone/claude_code_agent_farm](https://github.com/Dicklesworthstone/claude_code_agent_farm)** | Orchestration | Multiple Claude sessions in parallel, systematic codebase improvement |
+| **[connerlambden/helium-mcp](https://github.com/connerlambden/helium-mcp)** | MCP server | News intelligence, bias analysis, and market data (10 tools via MCP at https://heliumtrades.com/mcp) |
 
 ### **Individual Contributor Collections**
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 | **[webdevtodayjason/sub-agents](https://github.com/webdevtodayjason/sub-agents)** | CLI Manager | NPM installable, context-forge integration, bulk management |
 | **[baryhuang/claude-code-by-agents](https://github.com/baryhuang/claude-code-by-agents)** | Desktop app | Multi-agent workspace, @agent mentions, local+remote agents |
 | **[Dicklesworthstone/claude_code_agent_farm](https://github.com/Dicklesworthstone/claude_code_agent_farm)** | Orchestration | Multiple Claude sessions in parallel, systematic codebase improvement |
-| **[connerlambden/helium-mcp](https://github.com/connerlambden/helium-mcp)** | MCP server | News intelligence, bias analysis, and market data (10 tools via MCP at https://heliumtrades.com/mcp) |
+| **[connerlambden/helium-mcp](https://github.com/connerlambden/helium-mcp)** | MCP server | News intelligence, bias analysis, market data, 10 tools |
 
 ### **Individual Contributor Collections**
 


### PR DESCRIPTION
## Summary

Adds [Helium MCP](https://github.com/connerlambden/helium-mcp) as an MCP server for news intelligence, bias analysis, and market data (10 tools at https://heliumtrades.com/mcp).

## Checklist

- [x] Entry matches existing README table format in **Specialized Frameworks & Tools**

Made with [Cursor](https://cursor.com)