### PR TITLE
Add Not Human Search to Agent Sharing Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 
 ### **Agent Sharing Platforms**
 - **[subagents.cc](https://www.subagents.cc/)** - Dedicated Claude agent directory
+- **[Not Human Search](https://nothumansearch.ai/)** - Agent-first search engine indexing 8,000+ MCP servers and agent-readable services ranked by agentic readiness. Install as MCP: `claude mcp add --transport http nothumansearch https://nothumansearch.ai/mcp`
 - **Reddit Communities**: r/ClaudeAI, r/programming - Active sharing and discussion
 - **GitHub Topics**: #claude-agents, #claude-code, #subagents
 


### PR DESCRIPTION
Adds [Not Human Search](https://nothumansearch.ai) to the **Agent Sharing Platforms** subsection alongside subagents.cc.

NHS is an agent-discovery search engine — directly useful to readers of this list who want to *find* MCP servers and other agent-readable services to integrate into their Claude agent workflows. Different from subagents.cc (which focuses on Claude Code sub-agent markdown files) — NHS indexes external services agents *consume* (APIs, MCP servers, llms.txt sites).

One-liner MCP install provided for anyone who wants to query NHS directly from inside a Claude Code session:
`claude mcp add --transport http nothumansearch https://nothumansearch.ai/mcp`

- 8,000+ sites indexed across 7 agentic readiness signals
- Free REST API + MCP server; MIT
- Official MCP registry: `ai.nothumansearch/search`