### PR TITLE
Add shipcrew under Individual Contributor Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 | Repository | Sub-Agents | Specialization |
 |---|---|---|
 | **[iannuttall/claude-agents](https://github.com/iannuttall/claude-agents)** | 7 | Code refactoring, content writing, frontend design, PRD writing |
+| **[rockscy/shipcrew](https://github.com/rockscy/shipcrew)** | 6 | Repo-maintenance focus: PR review, issue triage, release notes, test failure investigation, dep updates, flake hunting. Bilingual EN+中文, structured output formats with confidence calibration. |
 | **[zhsama/claude-sub-agent](https://github.com/zhsama/claude-sub-agent)** | Workflow system | Spec-driven development pipeline with quality gates |
 
 ## 📚 Essential Guides & Documentation


### PR DESCRIPTION
Adding [shipcrew](https://github.com/rockscy/shipcrew) — a focused 6-subagent collection for repo maintenance tasks.

### What it is

Six Claude Code subagents that handle the recurring, boring work of maintaining a software repo:

- `pr-reviewer` — deep review of a single pull request with line-cited findings
- `issue-triager` — classifies a new issue into one of seven buckets and drafts a reply
- `release-notes-writer` — turns a tag range into user-facing release notes + a launch blurb
- `test-failure-investigator` — investigates one failing test, names a root cause, proposes a fix
- `dep-updater` — reads dependency manifests and produces a triage table (safe / risky / breaking)
- `flake-hunter` — scans CI history, identifies flaky tests, recommends quarantine + tracking issues

### What's distinguishing

- **Single-purpose only** — each agent does one thing; explicit handoff rules between them.
- **Confidence calibration** — every output declares high/medium/low confidence and abort conditions.
- **Hard rules section** — every agent explicitly states what it won't do (never approves PRs, never disables tests as a fix, etc.).
- **Fixed output formats** — tables, line citations, structured sections. No "let me give you some thoughts" prose.
- **Bilingual** — EN + 中文 docs (README, CONTRIBUTING).
- **One-line install** — drops `.md` files into `~/.claude/agents/`.

### Where I added it

Under **Individual Contributor Collections**, alphabetically between `iannuttall/claude-agents` and `zhsama/claude-sub-agent`.

Repo: https://github.com/rockscy/shipcrew