### PR TITLE
Add: ndesv21/socialclaw — social media publishing agent for 13 platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 | Repository | Sub-Agents | Specialization |
 |---|---|---|
 | **[iannuttall/claude-agents](https://github.com/iannuttall/claude-agents)** | 7 | Code refactoring, content writing, frontend design, PRD writing |
-| **[ndesv21/socialclaw](https://github.com/ndesv21/socialclaw)** | 1 | Social media publishing across 13 platforms via SocialClaw API |
+| **[ndesv21/socialclaw](https://github.com/ndesv21/socialclaw)** | 1 | Social media publishing across 13 platforms (X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest) via a single workspace API key |
 | **[zhsama/claude-sub-agent](https://github.com/zhsama/claude-sub-agent)** | Workflow system | Spec-driven development pipeline with quality gates |
 
 ## 📚 Essential Guides & Documentation

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 | Repository | Sub-Agents | Specialization |
 |---|---|---|
 | **[iannuttall/claude-agents](https://github.com/iannuttall/claude-agents)** | 7 | Code refactoring, content writing, frontend design, PRD writing |
+| **[ndesv21/socialclaw](https://github.com/ndesv21/socialclaw)** | 1 | Social media publishing across 13 platforms via SocialClaw API |
 | **[zhsama/claude-sub-agent](https://github.com/zhsama/claude-sub-agent)** | Workflow system | Spec-driven development pipeline with quality gates |
 
 ## 📚 Essential Guides & Documentation


### PR DESCRIPTION
Adds [ndesv21/socialclaw](https://github.com/ndesv21/socialclaw) to the Individual Contributor Collections table.

SocialClaw is an agent-driven social media publishing skill that connects Claude Code to 13 platforms (X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest) through a single workspace API key.

- Install: `npx skills add ndesv21/socialclaw`
- Service: https://getsocialclaw.com
- License: MIT