### PR TITLE
Add TWZRD Agent Intel to Agent Sharing Platforms — Solana x402 trust-scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 
 ### **Agent Sharing Platforms**
 - **[subagents.cc](https://www.subagents.cc/)** - Dedicated Claude agent directory
+- **[TWZRD Agent Intel](https://intel.twzrd.xyz)** - Trust-scoring MCP server for autonomous agents on Solana: free preflight trust check + signed V5 trust receipt via USDC micropayment. Tools: `resolve_agent`, `score_agent`, `get_trust_receipt`, `verify_trust_receipt`. [MCP](https://intel.twzrd.xyz/mcp) · [Registered at MCP Registry](https://registry.modelcontextprotocol.io)
 - **Reddit Communities**: r/ClaudeAI, r/programming - Active sharing and discussion
 - **GitHub Topics**: #claude-agents, #claude-code, #subagents
 


### PR DESCRIPTION
## Summary

Adds **TWZRD Agent Intel** to the Agent Sharing Platforms section under Community & Platforms.

As Claude agents increasingly operate autonomously and interact with each other, trust verification becomes critical infrastructure. TWZRD Agent Intel provides exactly this — a production MCP server for verifying agent trust before autonomous transactions.

### What it does

- **Free preflight check**: `resolve_agent` / `score_agent` — verify an agent's on-chain Solana trust score before interacting
- **Paid trust receipt**: `get_trust_receipt` — returns a cryptographically signed V5 trust receipt via USDC micropayment (<1s settlement on Solana via x402)
- **Verify**: `verify_trust_receipt` — validate a previously issued receipt
- **MCP endpoint**: `https://intel.twzrd.xyz/mcp` (Streamable-HTTP)
- Registered at `registry.modelcontextprotocol.io` as `xyz.twzrd.intel/twzrd-agent-intel v0.1.2`

### Why this fits here

Agent Sharing Platforms lists infrastructure that supports the Claude agent ecosystem. TWZRD Agent Intel is trust infrastructure — it answers the question "can I trust this agent?" before autonomous interactions happen, which is foundational for multi-agent workflows.

**Links**: [Website](https://intel.twzrd.xyz) · [GitHub](https://github.com/twzrd-sol/wzrd-final) · [MCP Registry](https://registry.modelcontextprotocol.io)