### PR TITLE
Add CreatorSkills to Agent Sharing Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 
 ### **Agent Sharing Platforms**
 - **[subagents.cc](https://www.subagents.cc/)** - Dedicated Claude agent directory
+- **[CreatorSkills](https://creatorskills.co)** - Marketplace of 30+ downloadable AI skills for content creators — YouTube scripting, sponsorship analysis, content repurposing, and audience growth. Skills use the open SKILL.md format and work with Claude, ChatGPT, and 20+ platforms.
 - **Reddit Communities**: r/ClaudeAI, r/programming - Active sharing and discussion
 - **GitHub Topics**: #claude-agents, #claude-code, #subagents
 


### PR DESCRIPTION
## Description

Adds [CreatorSkills](https://creatorskills.co) to the Agent Sharing Platforms section alongside subagents.cc.

CreatorSkills is a marketplace of 30+ downloadable AI skills for content creators — covering YouTube scripting, sponsorship analysis, content repurposing, and audience growth. Skills are distributed in the open SKILL.md format and are compatible with Claude, ChatGPT, and 20+ AI platforms.

It fits in the Agent Sharing Platforms section as a dedicated marketplace for distributing AI skills/agents to end users, with a specific focus on content creation workflows.