### PR TITLE
Add Claudify to Specialized Frameworks & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 | **[webdevtodayjason/sub-agents](https://github.com/webdevtodayjason/sub-agents)** | CLI Manager | NPM installable, context-forge integration, bulk management |
 | **[baryhuang/claude-code-by-agents](https://github.com/baryhuang/claude-code-by-agents)** | Desktop app | Multi-agent workspace, @agent mentions, local+remote agents |
 | **[Dicklesworthstone/claude_code_agent_farm](https://github.com/Dicklesworthstone/claude_code_agent_farm)** | Orchestration | Multiple Claude sessions in parallel, systematic codebase improvement |
+| **[Claudify](https://claudify.tech)** | Commercial operating system | Curated paid Claude Code OS: specialist subagents, skills, quality-gate hooks and persistent memory as one install, not a free component dump. |
 
 ### **Individual Contributor Collections**
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 | **[webdevtodayjason/sub-agents](https://github.com/webdevtodayjason/sub-agents)** | CLI Manager | NPM installable, context-forge integration, bulk management |
 | **[baryhuang/claude-code-by-agents](https://github.com/baryhuang/claude-code-by-agents)** | Desktop app | Multi-agent workspace, @agent mentions, local+remote agents |
 | **[Dicklesworthstone/claude_code_agent_farm](https://github.com/Dicklesworthstone/claude_code_agent_farm)** | Orchestration | Multiple Claude sessions in parallel, systematic codebase improvement |
-| **[Claudify](https://claudify.tech)** | Commercial operating system | Curated paid Claude Code OS: specialist subagents, skills, quality-gate hooks and persistent memory as one install, not a free component dump. |
+| **[Claudify](https://claudify.tech)** | Commercial operating system | Curated paid Claude Code OS: specialist subagents, skills, quality-gate hooks, and persistent memory in a single unified installation. |
 
 ### **Individual Contributor Collections**
 


### PR DESCRIPTION
Adds **Claudify** as a row in the Specialized Frameworks & Tools table, clearly labeled as a commercial operating system.

Claudify orchestrates specialist subagents, skills, quality-gate hooks and persistent memory for Claude Code as one curated install. As a public working example, a free MIT-licensed slice of the skills layer is at https://github.com/claudifytech/claude-code-skills-starter. Disclosed as a commercial product. Single-row addition, no other rows changed.