### PR TITLE
feat: add NotFair — SEO & paid-ads Claude Code skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 - **Sales**: Lead generators, email automators, CRM specialists
 - **Analytics**: Business analysts, growth hackers, conversion optimizers
 - **Support**: Customer service, FAQ creators, documentation writers
+- **SEO & Paid Ads**: **[nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)** — open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads (~2.9k stars, MIT). Connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. Skill areas: [seo/](https://github.com/nowork-studio/NotFair/tree/main/seo), [google-ads/](https://github.com/nowork-studio/NotFair/tree/main/google-ads), [meta-ads/](https://github.com/nowork-studio/NotFair/tree/main/meta-ads).
 
 ## 🌐 Community & Platforms
 


### PR DESCRIPTION
Hi, thanks for maintaining this directory!

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)** to the Business & Marketing section. It's an open-source set of Claude Code skills (MIT, ~2.9k stars) focused on SEO, GEO optimization, Google Ads, and Meta Ads. It connects to live account data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP — so the agents can actually read real campaign metrics and make changes, not just generate static copy.

The skill areas map to concrete folders in the repo: `seo/` (site audits, keyword research, meta tags, schema markup, content writing), `google-ads/` (audits, wasted-spend detection, keyword and bid management), and `meta-ads/` (ROAS analysis, creative fatigue, audience overlap).

I placed it in the existing "Business & Marketing" category as a new bullet. Happy to adjust the wording, move it to a different section, or trim if you'd prefer a shorter format. Let me know!