### PR TITLE
Add claude-code-arsenal to Production-Ready Agent Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 | **[davepoon/claude-code-subagents-collection](https://github.com/davepoon/claude-code-subagents-collection)** | 36 | Jul 2025 | Comprehensive collection with auto-delegation and best practices guide |
 | **[charles-adedotun/claude-code-sub-agents](https://github.com/charles-adedotun/claude-code-sub-agents)** | Full ecosystem | Jul 2025 | Workflow-stage based system mapping entire dev lifecycle |
 | **[thespamer/claude-code-arsenal](https://github.com/thespamer/claude-code-arsenal)** | 6 | Jun 2026 | Opinionated subagents with strict scope, read-only defaults, working demo project with seeded issues, real run output validation |
+| **[thespamer/claude-code-arsenal](https://github.com/thespamer/claude-code-arsenal)** | 6 | Jun 2026 | Opinionated subagents with strict scope, read-only defaults, working demo project with seeded issues, real run output validation |
 
 ### **Specialized Frameworks & Tools**
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 | **[vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents)** | 26 | Jul 2025 | AI development team with Tech Lead, Analyst, and specialized domain experts |
 | **[davepoon/claude-code-subagents-collection](https://github.com/davepoon/claude-code-subagents-collection)** | 36 | Jul 2025 | Comprehensive collection with auto-delegation and best practices guide |
 | **[charles-adedotun/claude-code-sub-agents](https://github.com/charles-adedotun/claude-code-sub-agents)** | Full ecosystem | Jul 2025 | Workflow-stage based system mapping entire dev lifecycle |
+| **[thespamer/claude-code-arsenal](https://github.com/thespamer/claude-code-arsenal)** | 6 | Jun 2026 | Opinionated subagents with strict scope, read-only defaults, working demo project with seeded issues, real run output validation |
 
 ### **Specialized Frameworks & Tools**
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 | **[charles-adedotun/claude-code-sub-agents](https://github.com/charles-adedotun/claude-code-sub-agents)** | Full ecosystem | Jul 2025 | Workflow-stage based system mapping entire dev lifecycle |
 | **[thespamer/claude-code-arsenal](https://github.com/thespamer/claude-code-arsenal)** | 6 | Jun 2026 | Opinionated subagents with strict scope, read-only defaults, working demo project with seeded issues, real run output validation |
 | **[thespamer/claude-code-arsenal](https://github.com/thespamer/claude-code-arsenal)** | 6 | Jun 2026 | Opinionated subagents with strict scope, read-only defaults, working demo project with seeded issues, real run output validation |
+| **[thespamer/claude-code-arsenal](https://github.com/thespamer/claude-code-arsenal)** | 6 | Jun 2026 | Opinionated subagents with strict scope, read-only defaults, working demo project with seeded issues, real run output validation |
 
 ### **Specialized Frameworks & Tools**
 


### PR DESCRIPTION
Adds [claude-code-arsenal](https://github.com/thespamer/claude-code-arsenal) to the **Production-Ready Agent Collections** table.

## What it is

A collection of six specialized Claude Code subagents:

- `architect` — codebase structure review, boundary violation detection (read-only)
- `security-auditor` — secrets, IAM, OWASP patterns, vulnerable deps sweep (read-only)
- `cost-sentinel` — flags patterns that look fine in dev and become expensive in prod (read-only)
- `test-fixer` — diagnoses failing tests across six failure modes, applies minimal fix (read + edit)
- `dependency-detective` — vulns, staleness, redundancy, license conflicts (read-only)
- `commit-curator` — reads staged diffs, drafts Conventional Commits messages (read-only audit)

## Why it fits this table

- Production-ready: Apache 2.0, vendor-neutral, includes working demo project
- Standard format: each subagent uses the YAML frontmatter Claude Code expects (`name`, `description`, `tools`, `model`)
- Validated: real run outputs with timings and screenshots in `demo/DEMO.md`
- Differentiates from existing entries by being smaller and more opinionated rather than comprehensive (6 focused agents vs. 36-100+ in other collections), and by including a seeded demo project for validation

Happy to address any feedback before merge.