### PR TITLE
Add agent-lsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 | **[webdevtodayjason/sub-agents](https://github.com/webdevtodayjason/sub-agents)** | CLI Manager | NPM installable, context-forge integration, bulk management |
 | **[baryhuang/claude-code-by-agents](https://github.com/baryhuang/claude-code-by-agents)** | Desktop app | Multi-agent workspace, @agent mentions, local+remote agents |
 | **[Dicklesworthstone/claude_code_agent_farm](https://github.com/Dicklesworthstone/claude_code_agent_farm)** | Orchestration | Multiple Claude sessions in parallel, systematic codebase improvement |
+| **[blackwell-systems/agent-lsp](https://github.com/blackwell-systems/agent-lsp)** | Code intelligence MCP server | Orchestrates language servers (gopls, rust-analyzer, pyright, etc.) into agent-native workflows: blast-radius analysis, find references/callers, rename, speculative editing. 65 tools, 30 languages, single Go binary |
 
 ### **Individual Contributor Collections**
 


### PR DESCRIPTION
Adds **agent-lsp** to the Specialized Frameworks & Tools table.

agent-lsp is an MCP server that orchestrates language servers (gopls, rust-analyzer, pyright, jdtls, etc.) into agent-native workflows: blast-radius analysis, find references/callers, rename, and speculative editing (preview diagnostics before writing to disk). 65 code intelligence tools across 30 CI-verified languages, shipped as a single Go binary, with 23 bundled Claude Code skills.

I matched the existing table format (Repository / Purpose / Key Features).