### PR TITLE
Add bufferBrew/craftsman (10 discipline-focused agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 |---|---|---|
 | **[iannuttall/claude-agents](https://github.com/iannuttall/claude-agents)** | 7 | Code refactoring, content writing, frontend design, PRD writing |
 | **[zhsama/claude-sub-agent](https://github.com/zhsama/claude-sub-agent)** | Workflow system | Spec-driven development pipeline with quality gates |
+| **[bufferBrew/craftsman](https://github.com/bufferBrew/craftsman)** | 10 | Engineering discipline: minimal-diff coding, root-cause debugging, recurring-bug detection, orchestrator with evidence-gated pipeline; installable Claude Code plugin |
 
 ## 📚 Essential Guides & Documentation
 


### PR DESCRIPTION
Adds [bufferBrew/craftsman](https://github.com/bufferBrew/craftsman) to the **Individual Contributor Collections** table.

Ten discipline-focused agents (orchestrator, planner, coder, reviewer, tester, security, release-prep, researcher, docs-writer, debugger) packaged as an installable Claude Code plugin. The orchestrator classifies each task, selects a minimal pipeline, and gates every stage on verified evidence; the coder is bound to minimal diffs and the debugger to established root causes. Also ships seven skills and cross-platform hooks. MIT licensed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)