### PR TITLE
Add oss-distributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The Claude Code agent ecosystem has exploded with hundreds of specialized sub-ag
 | **[webdevtodayjason/sub-agents](https://github.com/webdevtodayjason/sub-agents)** | CLI Manager | NPM installable, context-forge integration, bulk management |
 | **[baryhuang/claude-code-by-agents](https://github.com/baryhuang/claude-code-by-agents)** | Desktop app | Multi-agent workspace, @agent mentions, local+remote agents |
 | **[Dicklesworthstone/claude_code_agent_farm](https://github.com/Dicklesworthstone/claude_code_agent_farm)** | Orchestration | Multiple Claude sessions in parallel, systematic codebase improvement |
+| **[yarin-hochman1/oss-distributor](https://github.com/yarin-hochman1/oss-distributor)** | OSS distribution | Scores your project against awesome-lists/registries for fit, then opens PRs only after explicit approval. Install: `git clone https://github.com/yarin-hochman1/oss-distributor ~/.claude/agents/oss-distributor` |
 
 ### **Individual Contributor Collections**
 


### PR DESCRIPTION
Adds [oss-distributor](https://github.com/yarin-hochman1/oss-distributor) to the Specialized Frameworks & Tools table.

**What it is**: Refreshes a live GitHub snapshot of your repo, searches for awesome-lists and registries that fit your project's ecosystem, scores each candidate for fit, and opens pull requests only after you explicitly approve. Rate-limited to 5 PRs per session, skips lists that require human-only attestations, and never invents statistics about your project.

**License**: MIT
**Install**:
```
git clone https://github.com/yarin-hochman1/oss-distributor ~/.claude/agents/oss-distributor
```

Fits under Specialized Frameworks & Tools because it's a Claude Code agent/tool (not a subagent bundle), same category as the other framework/CLI-tool entries already in that table.